### PR TITLE
Fix some typos, grammar and spacing issues in script

### DIFF
--- a/Update/_meak_003.txt
+++ b/Update/_meak_003.txt
@@ -514,7 +514,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#5ec69a>魅音</color>", NULL, "<color=#5ec69a>Mion</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 3, "ps3/s06/03/150300071", 256, TRUE);
 	OutputLine(NULL, "それがオトナと呼べるかどうかは、",
-		   NULL, " I don't know if that should be called mature. ", Line_Continue);
+		   NULL, "I don't know if that should be called mature. ", Line_Continue);
 	Wait( 1200 );
 	OutputLine(NULL, "…私には難しいなぁ。」",
 		   NULL, "...It's hard for me to tell.\"", Line_Normal);

--- a/Update/_meak_006.txt
+++ b/Update/_meak_006.txt
@@ -711,7 +711,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>入江</color>", NULL, "<color=#c89a80>Irie</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s06/10/151000030", 256, TRUE);
 	OutputLine(NULL, "みんなで団結して共通の目標を目指すのは、とても素敵なことだと思いますからね。",
-		   NULL, " I think it's admirable to aim for victory together... ", GetGlobalFlag(GLinemodeSp));
+		   NULL, "I think it's admirable to aim for victory together... ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>入江</color>", NULL, "<color=#c89a80>Irie</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s06/10/151000031", 256, TRUE);
 	OutputLine(NULL, "……まぁ、ウチは、その目標がたまたま勝利じゃないってだけのことです。」",

--- a/Update/_meak_011.txt
+++ b/Update/_meak_011.txt
@@ -1807,7 +1807,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#a59da9>大石</color>", NULL, "<color=#a59da9>Ooishi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 11, "ps3/s06/11/150700130", 256, TRUE);
 	OutputLine(NULL, "それでも一緒に居たとおっしゃるわけで？",
-		   NULL, " Are you still saying that you were with him?", Line_WaitForInput);
+		   NULL, "Are you still saying that you were with him?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 11, "ps3/s06/11/150700131", 256, TRUE);
 	OutputLine(NULL, "　なっはっはっは……。",
 		   NULL, " Na ha ha ha...", Line_WaitForInput);

--- a/Update/_meak_024a.txt
+++ b/Update/_meak_024a.txt
@@ -879,7 +879,7 @@ void main()
 //r浮かれて、幸せいっぱいに喜んで、…私にのろけたりもしなかった。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "浮かれて、幸せいっぱいに喜んで、…私にのろけたりもしなかった。",
-			NULL, "She wouldn't been overjoyed, and cheerfully boasted about him to me.", GetGlobalFlag(GLinemodeSp));
+			NULL, "She wouldn't have been overjoyed, and cheerfully boasted about him to me.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 //r私はそれを聞いている内に、悟史くんのことを思い出して。

--- a/Update/_meak_badend.txt
+++ b/Update/_meak_badend.txt
@@ -273,7 +273,7 @@ void main()
 //r聞いた話では、…詩音は警察が突入した時には出血多量でもう、息をしていなかったらしい。
 	if (GetGlobalFlag(GADVMode)) { OutputLineAll("", NULL, Line_ContinueAfterTyping); }
 	OutputLine(NULL, "聞いた話では、…詩音は警察が突入した時には出血多量でもう、息をしていなかったらしい。",
-			NULL, "From what I had heard, Shion had already lost too much blood by the time the had police arrived... and she had stopped breathing.", GetGlobalFlag(GLinemodeSp));
+			NULL, "From what I had heard, Shion had already lost too much blood by the time the police had arrived... and she had stopped breathing.", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 //r急いで救急車を呼びつけて診療所に運び込んだが、手当てをする間もなく息を引き取ったそうだ…。
@@ -661,10 +661,10 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#5ec69a>魅音</color>", NULL, "<color=#5ec69a>Mion</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 3, "ps3/s06/03/330300198", 256, TRUE);
 	OutputLine(NULL, "「……へ？",
-			NULL, "\"......huh?", Line_WaitForInput);
+			NULL, "\"......Huh?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s06/03/330300199", 256, TRUE);
 	OutputLine(NULL, "　ど、どこへ…？」",
-			NULL, " ...w...where?\"", GetGlobalFlag(GLinemodeSp));
+			NULL, " ...W...where?\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 //圭一rvS06/01/330100424.「決まってるだろ、旅行だよ。kvS06/01/330100425.俺がここにいられる期間はもうあまりないけど、…だったらせめて、少しでもいい思い出を取り返しておかないとな」
@@ -818,7 +818,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#5ec69a>魅音</color>", NULL, "<color=#5ec69a>Mion</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 3, "ps3/s06/03/330300204", 256, TRUE);
 	OutputLine(NULL, "「…え、えっと。",
-			NULL, "\"...uh... ummm.", Line_WaitForInput);
+			NULL, "\"...Uh... ummm.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s06/03/330300205", 256, TRUE);
 	OutputLine(NULL, "う、うん…わ、わかった…。",
 			NULL, " O-okay... I-I gotcha....", Line_WaitForInput);
@@ -916,7 +916,7 @@ void main()
 			NULL, "\"Hey, hey, Kei-chan?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s06/03/330300210", 256, TRUE);
 	OutputLine(NULL, "　これからどこに行くの？」",
-			NULL, " ...where are we going after this?\"", GetGlobalFlag(GLinemodeSp));
+			NULL, " ...Where are we going after this?\"", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { ClearMessage(); } else { OutputLineAll(NULL, "\n", Line_ContinueAfterTyping); }
 
 //圭一rvS06/01/330100432.「そうだなぁ。kvS06/01/330100433.魅音の好みから考えて、…あそこはどうだ？」


### PR DESCRIPTION
Fixes some jumbled wording and grammar errors I noticed in the bad ending. Also deals with a few leading spaces throughout the script that seem to be misplaced at the beginning of dialogue.